### PR TITLE
Fixes syntactical error in the backup functions

### DIFF
--- a/func/backup_add.sh
+++ b/func/backup_add.sh
@@ -1,20 +1,31 @@
 #
 # Includes Backup Retention Configuration
 #
-scriptpath=`realpath $0` # This get the script path + the name, e.g /path/to/script/scriptname.sh
-scriptdir=`dirname $scriptpath` # This get the script directory e.g /path/to/script which is what I need
+scriptpath=$(realpath "$0") # This get the script path + the name, e.g /path/to/script/scriptname.sh
+scriptdir=$(dirname "$scriptpath") # This get the script directory e.g /path/to/script which is what I need
 
-source $scriptdir/backup.conf
+source "$scriptdir"/backup.conf
 
 backup_conf="$scriptdir/backup.conf"
+
+backupchecker() {
+
+    backupstat=$1
+
+    if [[ $restorestat != 0 ]];then
+    echo "Backup Error, Check backup_log/$date.log"
+    exit 1
+    fi
+
+}
 
 backup_add() {
   #
   #   Time For Backing Up
   # 
 
-  date=`date +"%Y-%m-%d"`
-  now=`date +"%c"`
+  date=$(date +"%Y-%m-%d")
+  now=$(date +"%c")
 
   echo -e "\t\t\t\tGetting Started..."
 
@@ -30,9 +41,9 @@ backup_add() {
           #
           if [[ "$dailybackup" = "" ]];then
               dailybackup=7
-              sed -i "s/dailybackup.*/dailybackup=$dailybackup/" $backup_conf # Pass the default daily value to the retention config
+              sed -i "s/dailybackup.*/dailybackup=$dailybackup/" "$backup_conf" # Pass the default daily value to the retention config
           else 
-              sed -i "s/dailybackup.*/dailybackup=$dailybackup/" $backup_conf # Pass the user daily value to the retention config
+              sed -i "s/dailybackup.*/dailybackup=$dailybackup/" "$backup_conf" # Pass the user daily value to the retention config
           fi
 
       read -p  $'\t\t\t\t'"How Many Weekly Backup Do You Want To Keep (Default To 4 If You Skip): " weeklybackup
@@ -40,10 +51,10 @@ backup_add() {
           #   If User Gives an Empty Answer, we Default it to 4 otherwise, we store the user input
           #
           if [[ "$weeklybackup" = "" ]];then
-              weeklybackup=7
-              sed -i "s/weeklybackup.*/weeklybackup=$weeklybackup/" $backup_conf # Pass the default weekly value to the retention config
+              weeklybackup=4
+              sed -i "s/weeklybackup.*/weeklybackup=$weeklybackup/" "$backup_conf" # Pass the default weekly value to the retention config
           else
-              sed -i "s/weeklybackup.*/weeklybackup=$weeklybackup/" $backup_conf # Pass the user weekly value to the retention config
+              sed -i "s/weeklybackup.*/weeklybackup=$weeklybackup/" "$backup_conf" # Pass the user weekly value to the retention config
           fi
 
       read -p  $'\t\t\t\t'"How Many Monthly Backup Do You Want To Keep (Default To 12 If You Skip): " monthlybackup
@@ -52,9 +63,9 @@ backup_add() {
           #
           if [[ "$monthlybackup" = "" ]];then
               monthlybackup=12
-              sed -i "s/monthlybackup.*/monthlybackup=$monthlybackup/" $backup_conf # Pass the default monthly value to the retention config
+              sed -i "s/monthlybackup.*/monthlybackup=$monthlybackup/" "$backup_conf" # Pass the default monthly value to the retention config
           else
-               sed -i "s/monthlybackup.*/monthlybackup=$monthlybackup/" $backup_conf # Pass the user monthly value to the retention config
+               sed -i "s/monthlybackup.*/monthlybackup=$monthlybackup/" "$backup_conf" # Pass the user monthly value to the retention config
           fi
 
           
@@ -65,8 +76,8 @@ backup_add() {
   # Store PAM Accounts For Use In Bind or SFTP Backup
   pamaccounts="/etc/passwd /etc/shadow /etc/group"
 
-  echo -e "\t\t\t\tInitiating - $now" | tee -a backup_log/$date.log #stdout -> log & stdout
-  echo -e "\t\t\t\tProgressing - $now" | tee -a backup_log/$date.log
+  echo -e "\t\t\t\tInitiating - $now" | tee -a backup_log/"$date".log #stdout -> log & stdout
+  echo -e "\t\t\t\tProgressing - $now" | tee -a backup_log/"$date".log
   echo
 
   #
@@ -87,7 +98,7 @@ backup_add() {
 
   echo -e "\t\t\t\tBacking up DNS Data if you have that created..."
 
-  if command -v named 2>> backup_log/$date.log &>/dev/null
+  if command -v named 2>> backup_log/"$date".log &
   then
       echo
 
@@ -101,13 +112,23 @@ backup_add() {
         # Create Bind Backup Directories If it is empty, this only happens once
         if [[ "$backupbind" = "" ]]; then
           backupbind=/backup/borg/bind
-          sed -i "s/backupbind.*/backupbind=\/backup\/borg\/bind/" $backup_conf
+          sed -i "s/backupbind.*/backupbind=\/backup\/borg\/bind/" "$backup_conf"
           mkdir -p $backupbind
-          echo -e "\t\t\t\tCreating Bind Repo - $now" | tee -a backup_log/$date.log
+          echo -e "\t\t\t\tCreating Bind Repo - $now" | tee -a backup_log/"$date".log
           borg init --encryption=none $backupbind
+
+          else
+
+          echo "
+                  Looks Like You Want To Recreate The DNS Backup Folder,
+                  This Should Only Happen Once, But If For Some reason Your
+                  Files Aren't Being Backed Up, You Need To Empty The Directory In The 
+                  backup.conf, e.g, if you have backupbind=/backup/borg/bind, make sure it is 
+                  empty, e.g backupbind= and retry backing up
+                  " | boxes -d columns 
         fi
 
-           echo -e "\t\t\t\tBacking Up Bind Data - $now" | tee -a backup_log/$date.log
+           echo -e "\t\t\t\tBacking Up Bind Data - $now" | tee -a backup_log/"$date".log
 
            bind=/etc/bind # If there is bind directory, we store it for compression
 
@@ -120,14 +141,22 @@ backup_add() {
             --show-rc                       \
             --compression lz4               \
                                             \
-            $backupbind::$date "$bind" $pamaccounts 2>> backup_log/$date.log >/dev/null &
+            $backupbind::"$date" "$bind" $pamaccounts 2>> backup_log/"$date".log &
+
+            # This waits for a the above background job to complete.
+            # $! represents process id of the most recent background job.
+            # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+            wait $!
+
+            backupchecker $? # We then use this to check the exit status of the completed program we waited for above
+
             echo
-            echo -e "\t\t\t\tBind Backed Up - $now" | tee -a backup_log/$date.log
+            echo -e "\t\t\t\tBind Backed Up - $now" | tee -a backup_log/"$date".log
 
             #
             #  Prune options decide what particular archives from your Borg backup get deleted over time
             #
-            #  The below Keeps Seven Daily Backups, Four Weekly Backups, and Twelve Monthly Backups
+            #  The below Keeps Seven Daily Backups by default, Four Weekly Backups, and Twelve Monthly Backups
             #  This is kinda confusing, but this is how it works, say you only have --keep-daily 7, it will keep the latest 
             #  backup on each of the most recent 7 days which have backups. 
             #  This means it would keep the last daily backup (for up to 7 days).
@@ -136,8 +165,15 @@ backup_add() {
             #  So, day 8 would be the new day 1, this is what it means by keep-daily for 7 days
             #
 
-          echo -e "\t\t\t\tPruning Bind data - $now" | tee -a backup_log/$date.log
-          borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupbind 2>> backup_log/$date.log >/dev/null &
+          echo -e "\t\t\t\tPruning Bind data - $now" | tee -a backup_log/"$date".log
+          borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupbind 2>> backup_log/"$date".log >/dev/null &
+
+          # This waits for a the above background job to complete.
+          # $! represents process id of the most recent background job.
+          # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+          wait $!
+
+          backupchecker $? # We then use this to check the exit status of the completed program we waited for above
 
 
           
@@ -151,36 +187,46 @@ backup_add() {
   #
   #   Checking mariadb Availability
   #
-  if command -v mariadb 2>> backup_log/$date.log &>/dev/null
+  if command -v mariadb 2>> backup_log/"$date".log &
   then
       echo
       echo -e "\t\t\t\tChecking mariadb Availability...."
       echo -e "\t\t\t\tmariadb okay...."
-      echo -e "\t\t\t\tBacking Up All mariadb database - $now" | tee -a backup_log/$date.log
+      echo -e "\t\t\t\tBacking Up All mariadb database - $now" | tee -a backup_log/"$date".log
 
 
       echo -e "\t\t\t\tEnter Mysql root Password: \c"
       read -s mysqlpass
 
       # Until The Password is Correct, Keep Looping
-      until mysql -u root -p$mysqlpass  -e ";" ; do
+      until mysql -u root -p"$mysqlpass"  -e ";" ; do
        read -s -p  $'\t\t\t\t'"Incorrect Password, Please Retry: " mysqlpass
       done
 
+      echo
       echo -e "\t\t\t\tPassword Correct: \c" 
 
-      mysqldump --user=root --password=$mysqlpass --lock-tables --all-databases > dbs.sql
+      mysqldump --user=root --password="$mysqlpass" --lock-tables --all-databases > dbs.sql
 
-      echo >> $backup_conf
-      echo "mysqlpass=$mysqlpass" >> $backup_conf # Pass rclone path to the retention config 
+      echo >> "$backup_conf"
+      sed -i "s/mysqlpass.*/mysqlpass=$mysqlpass/" "$backup_conf" # Add Mysql Pass
 
         # Create Database Backup Directories If it is empty, this only happens once
         if [[ "$backupdatabase" = "" ]]; then
           backupdatabase=/backup/borg/database
-          sed -i "s/backupdatabase.*/backupdatabase=\/backup\/borg\/database/" $backup_conf
+          sed -i "s/backupdatabase.*/backupdatabase=\/backup\/borg\/database/" "$backup_conf"
           mkdir -p $backupdatabase
-          echo -e "\t\t\t\tCreating Database Repo - $now" | tee -a backup_log/$date.log
+          echo -e "\t\t\t\tCreating Database Repo - $now" | tee -a backup_log/"$date".log
           borg init --encryption=none $backupdatabase
+
+        else
+          echo "
+                  Looks Like You Want To Recreate The Database Backup Folder,
+                  This Should Only Happen Once, But If For Some reason Your
+                  Files Aren't Being Backed Up, You Need To Empty The Directory In The 
+                  backup.conf, e.g, if you have backupdatabase=/backup/borg/database, make sure it is 
+                  empty, e.g backupdatabase= and retry backing up
+                  " | boxes -d columns 
         fi
 
 
@@ -193,12 +239,26 @@ backup_add() {
         --show-rc                       \
         --compression lz4               \
                                         \
-        $backupdatabase::$date dbs.sql  2>> backup_log/$date.log >/dev/null &
-        echo
-        echo -e "\t\t\t\tDatabase Backed Up - $now" | tee -a backup_log/$date.log
+        $backupdatabase::"$date" dbs.sql  2>> backup_log/"$date".log >/dev/null &
+        # This waits for a the above background job to complete.
+        # $! represents process id of the most recent background job.
+        # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+        wait $!
 
-          echo -e "\t\t\t\tPruning Full database data - $now" | tee -a backup_log/$date.log
-          borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupdatabase 2>> backup_log/$date.log >/dev/null &
+        backupchecker $? # We then use this to check the exit status of the completed program we waited for above
+
+        echo
+        echo -e "\t\t\t\tDatabase Backed Up - $now" | tee -a backup_log/"$date".log
+
+          echo -e "\t\t\t\tPruning Full database data - $now" | tee -a backup_log/"$date".log
+          borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupdatabase 2>> backup_log/"$date".log >/dev/null &
+
+          # This waits for a the above background job to complete.
+          # $! represents process id of the most recent background job.
+          # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+          wait $!
+
+          backupchecker $? # We then use this to check the exit status of the completed program we waited for above
 
           rm dbs.sql
 
@@ -225,13 +285,21 @@ backup_add() {
         # Create SFTP Backup Directories If it is empty, this only happens once
         if [[ "$backupsftp" = "" ]]; then
           backupsftp=/backup/borg/sftp
-          sed -i "s/backupsftp.*/backupsftp=\/backup\/borg\/sftp/" $backup_conf
+          sed -i "s/backupsftp.*/backupsftp=\/backup\/borg\/sftp/" "$backup_conf"
           mkdir -p $backupsftp
-          echo -e "\t\t\t\tCreating SFTP Repo - $now" | tee -a backup_log/$date.log
+          echo -e "\t\t\t\tCreating SFTP Repo - $now" | tee -a backup_log/"$date".log
           borg init --encryption=none $backupsftp
+        else
+          echo "
+                 Looks Like You Want To Recreate The SFTP Backup Folder,
+                 This Should Only Happen Once, But If For Some reason Your
+                 Files Aren't Being Backed Up, You Need To Empty The Directory In The 
+                 backup.conf, e.g, if you have backupsftp=/backup/borg/sftp, make sure it is 
+                 empty, e.g backupsftp= and retry backing up
+                 " | boxes -d columns 
         fi
 
-      echo -e "\t\t\t\tBacking Up All SFTP Users - $now" | tee -a backup_log/$date.log
+      echo -e "\t\t\t\tBacking Up All SFTP Users - $now" | tee -a backup_log/"$date".log
 
       # This store all the file into the bkdate, which would be inside backup_todaysdate
         borg create                       \
@@ -242,13 +310,27 @@ backup_add() {
           --show-rc                       \
           --compression lz4               \
                                           \
-          $backupsftp::$date "$sftp" $pamaccounts 2>> backup_log/$date.log >/dev/null &
+          $backupsftp::"$date" "$sftp" $pamaccounts 2>> backup_log/"$date".log &
+
+          # This waits for a the above background job to complete.
+          # $! represents process id of the most recent background job.
+          # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+          wait $!
+
+          backupchecker $? # We then use this to check the exit status of the completed program we waited for above
           echo
-          echo -e "\t\t\t\tSFTP Backed Up - $now" | tee -a backup_log/$date.log
+          echo -e "\t\t\t\tSFTP Backed Up - $now" | tee -a backup_log/"$date".log
 
 
-          echo -e "\t\t\t\tPruning SFTP Users Data - $now" | tee -a backup_log/$date.log
-          borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupsftp 2>> backup_log/$date.log >/dev/null &
+          echo -e "\t\t\t\tPruning SFTP Users Data - $now" | tee -a backup_log/"$date".log
+          borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupsftp 2>> backup_log/"$date".log >/dev/null &
+
+          # This waits for a the above background job to complete.
+          # $! represents process id of the most recent background job.
+          # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+          wait $!
+
+          backupchecker $? # We then use this to check the exit status of the completed program we waited for above
           
   fi # END [ ! -d /sftpusers/jailed ];
 
@@ -268,11 +350,24 @@ backup_add() {
         # Create Certificate Backup Directories If it is empty, this only happens once
         if [[ "$backupletsencrypt" = "" ]]; then
           backupletsencrypt=/backup/borg/letsencrypt
-          sed -i "s/backupletsencrypt.*/backupletsencrypt=\/backup\/borg\/letsencrypt/" $backup_conf
+          sed -i "s/backupletsencrypt.*/backupletsencrypt=\/backup\/borg\/letsencrypt/" "$backup_conf"
           mkdir -p $backupletsencrypt
-          echo -e "\t\t\t\tCreating Cert Repo - $now" | tee -a backup_log/$date.log
+          echo -e "\t\t\t\tCreating Cert Repo - $now" | tee -a backup_log/"$date".log
           borg init --encryption=none $backupletsencrypt
+
+        else
+
+        echo "
+                 Looks Like You Want To Recreate The Letsencrypt Backup Folder,
+                 This Should Only Happen Once, But If For Some reason Your
+                 Files Aren't Being Backed Up, You Need To Empty The Directory In The 
+                 backup.conf, e.g, if you have backupletsencrypt=/backup/borg/letsencrypt, make sure it is 
+                 empty, e.g backupletsencrypt= and retry backing up
+                 " | boxes -d columns 
+
         fi
+
+     echo -e "\t\t\t\tBacking Up All Letsencrypt Certificate - $now" | tee -a backup_log/"$date".log
 
      borg create                       \
         --verbose                       \
@@ -282,12 +377,25 @@ backup_add() {
         --show-rc                       \
         --compression lz4               \
                                         \
-        $backupletsencrypt::$date "$letsencrypt"  2>> backup_log/$date.log >/dev/null &
-        echo
-        echo -e "\t\t\t\tLetsencrypt Backed Up - $now" | tee -a backup_log/$date.log
+        $backupletsencrypt::"$date" "$letsencrypt"  2>> backup_log/"$date".log &
+        # This waits for a the above background job to complete.
+        # $! represents process id of the most recent background job.
+        # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+        wait $!
 
-         echo -e "\t\t\t\tPruning Letsencrypt Cert Data - $now" | tee -a backup_log/$date.log
-         borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupletsencrypt 2>> backup_log/$date.log >/dev/null &
+        backupchecker $? # We then use this to check the exit status of the completed program we waited for above
+        echo
+        echo -e "\t\t\t\tLetsencrypt Backed Up - $now" | tee -a backup_log/"$date".log
+
+         echo -e "\t\t\t\tPruning Letsencrypt Cert Data - $now" | tee -a backup_log/"$date".log
+         borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupletsencrypt 2>> backup_log/"$date".log >/dev/null &
+
+         # This waits for a the above background job to complete.
+         # $! represents process id of the most recent background job.
+         # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+         wait $!
+
+         backupchecker $? # We then use this to check the exit status of the completed program we waited for above
           
   fi # END [ ! -d /etc/letsencrypt ]
 
@@ -298,7 +406,7 @@ backup_add() {
 
   echo -e "\t\t\t\tChecking Nginx Config and Vhost..."
 
-  if command -v nginx 2>> backup_log/$date.log &>/dev/null
+  if command -v nginx 2>> backup_log/"$date".log &
   then
       echo
       echo -e "\t\t\t\tNginx okay...."
@@ -313,16 +421,27 @@ backup_add() {
         # Create Site Backup Directories If it is empty, this only happens once
         if [[ "$backupsitedir" = "" ]]; then
           backupsitedir=/backup/borg/sitedir
-          sed -i "s/backupsitedir.*/backupsitedir=\/backup\/borg\/sitedir/" $backup_conf
+          sed -i "s/backupsitedir.*/backupsitedir=\/backup\/borg\/sitedir/" "$backup_conf"
           mkdir -p $backupsitedir
-          echo -e "\t\t\t\tCreating Site Dir Repo - $now" | tee -a backup_log/$date.log
+          echo -e "\t\t\t\tCreating Site Dir Repo - $now" | tee -a backup_log/"$date".log
           borg init --encryption=none $backupsitedir
+
+        else
+
+          echo "
+                  Looks Like You Want To Recreate The Site Directory Backup Folder,
+                  This Should Only Happen Once, But If For Some reason Your
+                  Files Aren't Being Backed Up, You Need To Empty The Directory In The 
+                  backup.conf, e.g, if you have backupsitedir=/backup/borg/sitedir, make sure it is 
+                  empty, e.g backupsitedir= and retry backing up
+                  " | boxes -d columns 
+          
         fi
 
         nginxconfig=/etc/nginx  # If there is an nginx directory, we store it for compression later
         vhosts=/var/www         # If there is a /var/www directory, we store it for compression later
 
-        echo -e "\t\t\t\tBacking Up Nginx Config and All Sites Vhosts Data - $now" | tee -a backup_log/$date.log
+        echo -e "\t\t\t\tBacking Up Nginx Config and All Sites Vhosts Data - $now" | tee -a backup_log/"$date".log
 
         # This store all the file into the bkdate, which would be inside nginx_todaysdate
         # This store all the website vhost; /var/www
@@ -335,12 +454,25 @@ backup_add() {
           --show-rc                       \
           --compression lz4               \
                                           \
-          $backupsitedir::$date "$vhosts" "$nginxconfig"  2>> backup_log/$date.log >/dev/null &
-          echo
-          echo -e "\t\t\t\tSite Dir Backed Up - $now" | tee -a backup_log/$date.log
+          $backupsitedir::"$date" "$vhosts" "$nginxconfig"  2>> backup_log/"$date".log &
+          # This waits for a the above background job to complete.
+          # $! represents process id of the most recent background job.
+          # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+          wait $!
 
-          echo -e "\t\t\t\tPruning Nginx and vhost data - $now" | tee -a backup_log/$date.log
-          borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupsitedir 2>> backup_log/$date.log >/dev/null &
+          backupchecker $? # We then use this to check the exit status of the completed program we waited for above
+          echo
+          echo -e "\t\t\t\tSite Dir Backed Up - $now" | tee -a backup_log/"$date".log
+
+          echo -e "\t\t\t\tPruning Nginx and vhost data - $now" | tee -a backup_log/"$date".log
+          borg prune -v --list --keep-daily=$dailybackup --keep-weekly=$weeklybackup --keep-monthly=$monthlybackup $backupsitedir 2>> backup_log/"$date".log >/dev/null &
+
+          # This waits for a the above background job to complete.
+          # $! represents process id of the most recent background job.
+          # So, we are basically using the $! to store the process id, and we use wait to wait for the job to complete
+          wait $!
+
+          backupchecker $? # We then use this to check the exit status of the completed program we waited for above
 
       fi # END [[ ! -d /etc/nginx && ! -d /var/www ]]
 
@@ -370,19 +502,19 @@ echo "
     $vhosts                         \ # This store all the website vhost; /var/www
     $nginxconfig                    \ # This store all the nginx config; /etc/nginx
     $sftp                           \
-    $letsencrypt  2>> backup_log/$date.log >/dev/null &
+    $letsencrypt  2>> backup_log/$date.log &
 
 " &>/dev/null
 
 #   Setting Cron Permission
 
-chmod a+x $scriptdir/backup_cron.sh
+chmod a+x "$scriptdir"/backup_cron.sh
 
 #
 # Checking If Rclone Path is Set, if Yes, we sync to rclone path
 #
 
-if command -v rclone 2>> backup_log/$date.log &>/dev/null
+if command -v rclone 2>> backup_log/"$date".log &
 then 
     echo -e "\t\t\t\tRclone Okay"
 else
@@ -400,22 +532,22 @@ then
 
     if [[ "$rcloneto" = "" ]];then
         rcloneto=
-        sed -i "s/rcloneto.*/rcloneto=$rcloneto/" $backup_conf # Make rcloneto empty
+        sed -i "s/rcloneto.*/rcloneto=$rcloneto/" "$backup_conf" # Make rcloneto empty
     else
-        sed -i "s/rcloneto.*/rcloneto=$rcloneto/" $backup_conf # Pass rclone path to the retention config
+        sed -i "s/rcloneto.*/rcloneto=$rcloneto/" "$backup_conf" # Pass rclone path to the retention config
     fi
 fi
 
 
 if [[ -z "$rcloneto" ]]; then
 
-    echo "Not Pushing To Cloud Storage"
+    echo -e "\t\t\t\tNot Pushing To Cloud Storage"
 
 else
 
     FROM=/backup/borg
     start=$(date +'%s')
-    echo "$(date "+%Y-%m-%d %T") RCLONE Sync Started" | tee -a backup_log/$date.log
+    echo "$(date "+%Y-%m-%d %T") RCLONE Sync Started" | tee -a backup_log/"$date".log
     #
     #   --transfers means the number of file transfers to run in parallel
     #
@@ -428,12 +560,12 @@ else
     #   --min-age 2h means no files younger than 2 hours will be transferred.
     #
 
-    rclone sync "$FROM" "$rcloneto" --transfers=20 --checkers=15 --delete-after --min-age 2h --log-file=backup_log/$date.log
-    echo "$(date "+%Y-%m-%d %T") RCLONE Upload Apparently Succeeded IN $(($(date +'%s') - $start)) SECONDS" | tee -a backup_log/$date.log
+    rclone sync "$FROM" "$rcloneto" --transfers=20 --checkers=15 --delete-after --min-age 2h --log-file=backup_log/"$date".log
+    echo "$(date "+%Y-%m-%d %T") RCLONE Upload Apparently Succeeded IN $(($(date +'%s') - $start)) SECONDS" | tee -a backup_log/"$date".log
 fi
 
-scriptpath=`realpath $0` # This get the script path + the name, e.g /path/to/script/scriptname.sh
-scriptdir=`dirname $scriptpath` # This get the script directory e.g /path/to/script which is what I need
+scriptpath=$(realpath "$0") # This get the script path + the name, e.g /path/to/script/scriptname.sh
+scriptdir=$(dirname "$scriptpath") # This get the script directory e.g /path/to/script which is what I need
 
 echo "
          Note: To Periodically Run The Backup, You Should add 

--- a/func/backup_edit_retention.sh
+++ b/func/backup_edit_retention.sh
@@ -1,5 +1,5 @@
-scriptpath=`realpath $0` # This get the script path + the name, e.g /path/to/script/scriptname.sh
-scriptdir=`dirname $scriptpath` # This get the script directory e.g /path/to/script which is what I need
+scriptpath=$(realpath $0) # This get the script path + the name, e.g /path/to/script/scriptname.sh
+scriptdir=$(dirname $scriptpath) # This get the script directory e.g /path/to/script which is what I need
 
 source $scriptdir/backup.conf
 


### PR DESCRIPTION
- Fixes Multiple redirections competing for stdout.
- Fixes cd logic, now, we can now test if the path exit or it returns an exit status other than zero
- Swapped legacy backtick command substitution `...`  which is a legacy syntax with several issues with $(...) command substitution has none of these problems
- Added quotes to variables to prevent word splitting